### PR TITLE
Enhance bio access and contact options

### DIFF
--- a/config/_default/menus.yaml
+++ b/config/_default/menus.yaml
@@ -7,6 +7,9 @@ main:
   - name: Home
     url: "/#home"         # We’ll define an id for the top section
     weight: 10
+  - name: About
+    url: "/authors/admin/"
+    weight: 15
   - name: Research Interests
     url: "/#research"     # anchor to Research section
     weight: 20
@@ -22,3 +25,6 @@ main:
   - name: CV
     url: "uploads/cv.pdf"
     weight: 80
+  - name: Contact
+    url: "/#contact"
+    weight: 90

--- a/content/_index.md
+++ b/content/_index.md
@@ -14,7 +14,7 @@ sections:
     css_class: dark hero-stroke
     content:
       username: admin
-      text: ""
+      text: "I'm an Assistant Professor at Georgia State University exploring artificial intelligence for cybersecurity. [Learn more about me.](/authors/admin/)"
       button:
         text: Download CV
         url: uploads/cv.pdf
@@ -68,8 +68,17 @@ sections:
     content:
       title: Awards & Honors
       text: |-
-        - **ACM SIGMIS Doctoral Dissertation Award**, 2024 (for the top IS dissertation of the year).  
-        - **Best Paper Award**, IEEE International Conference on Intelligence and Security Informatics (ISI) 2020 and 2023.  
+        - **ACM SIGMIS Doctoral Dissertation Award**, 2024 (for the top IS dissertation of the year).
+        - **Best Paper Award**, IEEE International Conference on Intelligence and Security Informatics (ISI) 2020 and 2023.
         - NSF Scholarship-for-Service Fellowship, 2018–2021 (full scholarship and stipend for cybersecurity study).
     design: { columns: "1" }
+
+  - block: markdown
+    id: contact
+    content:
+      title: Contact
+      text: |-
+        I'd love to connect. Email me at [bampel@gsu.edu](mailto:bampel@gsu.edu) or reach out on [LinkedIn](https://www.linkedin.com/in/benampel/).
+    design:
+      columns: "1"
 ---


### PR DESCRIPTION
## Summary
- Highlight bio and CV with a short introduction on the homepage hero section
- Add an accessible Contact section for email and LinkedIn outreach
- Expand navigation with About and Contact links for easier discovery

## Testing
- `hugo --minify` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/403)*
- `go install github.com/gohugoio/hugo@latest` *(fails: module proxy forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6896389fce748331afc493094304bc73